### PR TITLE
Allowing non health potions to be reset during combat.

### DIFF
--- a/conf/reusablepotion.conf.dist
+++ b/conf/reusablepotion.conf.dist
@@ -15,7 +15,7 @@
 #                     1 - Enabled
 #
 
-ReusablePotion.Enable = 1
+ReusablePotion.Enable = 0
 
 #
 #    ReusablePotion.EnableHealing

--- a/conf/reusablepotion.conf.dist
+++ b/conf/reusablepotion.conf.dist
@@ -7,6 +7,7 @@
 ########################################
 # ReusablePotion configuration
 ########################################
+
 #
 #    ReusablePotion.Enable
 #        Description: Enables potions to be re-usable in combat.
@@ -14,7 +15,34 @@
 #                     1 - Enabled
 #
 
-ReusablePotion.Enable = 0
+ReusablePotion.Enable = 1
+
+#
+#    ReusablePotion.EnableHealing
+#        Description: Enables Healing potions to be re-usable in combat
+#        Default:     0 - Disabled
+#                     1 - Enabled
+#
+
+ReusablePotion.EnableHealing = 1
+
+#
+#    ReusablePotion.EnableAura
+#        Description: Enables Aura potions to be re-usable in combat. Eg haste potion,restoration potion
+#        Default:     0 - Disabled
+#                     1 - Enabled
+#
+
+ReusablePotion.EnableAura = 1
+
+#
+#    ReusablePotion.EnableMana
+#        Description: Enables Mana potions to be re-usable in combat.
+#        Default:     0 - Disabled
+#                     1 - Enabled
+#
+
+ReusablePotion.EnableMana = 1
 
 #
 #    ReusablePotion.Verbose

--- a/src/MP_loader.cpp
+++ b/src/MP_loader.cpp
@@ -3,13 +3,13 @@
  */
 
 // From SC
-void AddMyReusablePotionScripts();
+void AddMyCustomReusablePotionScripts();
 
 // Add all
 // cf. the naming convention https://github.com/azerothcore/azerothcore-wotlk/blob/master/doc/changelog/master.md#how-to-upgrade-4
 // additionally replace all '-' in the module folder name with '_' here
 void AddReusablePotionScripts()
 {
-    AddMyReusablePotionScripts();
+    AddMyCustomReusablePotionScripts();
 }
 

--- a/src/ReusablePotion.h
+++ b/src/ReusablePotion.h
@@ -16,25 +16,33 @@ bool GetPlayerPvPState(Player* /*player*/);
 enum ReusablePotConstants
 {
     REUSE_SPELL_EFFECT_HEAL = 10,
+    REUSE_SPELL_EFFECT_MANA = 30,
+    REUSE_SPELL_EFFECT_AURA = 6,
     REUSE_SPELL_EFFECT_TARGET_SELF = 1,
     REUSE_SPELL_VISUAL_POTION = 147,
-    REUSE_SPELL_COOLDOWN_BASE = 60
+    REUSE_SPELL_VISUAL_POTION_OTHER_ONE = 633,
+    REUSE_SPELL_VISUAL_POTION_FREE_ACTION = 7119,
+    REUSE_SPELL_COOLDOWN_BASE = 25
 };
 
 class ReusablePotionPlayerScript : public PlayerScript
 {
+private:
+    bool usedPotion = false;
+    SpellInfo const* spellStorage;
+    Player * lastPlayerPotion;
 public:
     ReusablePotionPlayerScript() : PlayerScript("ReusablePotionPlayerScript") { }
-
     void OnPlayerLeaveCombat(Player* /*player*/) override;
+    void OnSpellCast(Player* /*player*/, Spell* /*spell*/, bool /*skipCheck*/) override;
 };
 
 class ReusablePotionUnitScript : public UnitScript
 {
 public:
     ReusablePotionUnitScript() : UnitScript("ReusablePotionUnitScript") { }
-    void ModifyHealReceived(Unit* /*target*/, Unit* /*healer*/, uint32& /*addHealth*/, SpellInfo const* /*spellInfo*/) override;
     void OnDamage(Unit* /*attacker*/, Unit* /*victim*/, uint32& /*damage*/) override;
+   // void OnAuraApply(Unit* /*unit*/, Aura* /*aura*/) override;
+  //  void ModifyHealReceived(Unit* /*target*/, Unit* /*healer*/, uint32& /*addHealth*/, SpellInfo const* /*spellInfo*/) override;
 };
-
 #endif // MODULE_REUSABLE_POTION_H


### PR DESCRIPTION
I made this fork a few months ago and didn't upload it to github been using it a on a server with a mate and we don't seem to be having any problems.

It works by checking every spellcast, if that spellcast is a potion and the config is set to allow that type of potion it saves the player pointer and on the next spell cast, server wide, it sends a cooldown request to that player allowing the potion cooldown to work during combat.

the reason it has to be done on the next spellcast is that the cooldown cannot be sent until after the spell has resolved, this bypasses that by forcing the request to be sent after the spell has been processed. 